### PR TITLE
[fix/#23] - calender data 오류 수정

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -31,13 +31,13 @@ export type Database = {
         Row: {
           contents: string | null;
           created_at: string;
-          end: string | null;
+          end: string;
           file: string | null;
           likeCount: number | null;
           liked: boolean | null;
           nickname: string | null;
-          start: string | null;
-          title: string | null;
+          start: string;
+          title: string;
           todoId: string;
         };
         Insert: {

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -6,13 +6,12 @@ import listPlugin from '@fullcalendar/list';
 import './calendar.css';
 import { supabase } from '@/supabase/supabase';
 import { useQuery } from '@tanstack/react-query';
+import { TodosInCalendar } from '../types/todoInCalendar';
 
 const CalendarPage = () => {
-  const {
-    data: todos,
-    isLoading,
-    isError,
-  } = useQuery({
+  const todos: TodosInCalendar = [];
+
+  const { data, isLoading, isError } = useQuery({
     queryKey: ['todos'],
     queryFn: async () => {
       try {
@@ -24,30 +23,13 @@ const CalendarPage = () => {
     },
   });
 
-  console.log(todos);
-
-  // const events = [
-  //   {
-  //     title: '아침 먹기',
-  //     start: '2024-03-17',
-  //     end: '2024-03-17',
-  //   },
-  //   {
-  //     title: '점심 먹기',
-  //     start: '2024-03-19',
-  //     end: '2024-03-20',
-  //   },
-  //   {
-  //     title: '저녁 먹기',
-  //     start: '2024-03-23',
-  //     end: '2024-03-30',
-  //   },
-  //   {
-  //     title: '디저트 먹기',
-  //     start: '2024-03-25',
-  //     end: '2024-03-27',
-  //   },
-  // ];
+  data?.map((item) =>
+    todos.push({
+      title: item.title,
+      start: item.start,
+      end: item.end,
+    })
+  );
 
   return (
     <>
@@ -56,8 +38,6 @@ const CalendarPage = () => {
           initialView="dayGridMonth"
           plugins={[dayGridPlugin]}
           events={todos}
-          // eventClick={() => alert('hi')}
-          // eventContent={renderEventContent}
         />
       </section>
       {/* <section>

--- a/src/app/types/todoInCalendar.ts
+++ b/src/app/types/todoInCalendar.ts
@@ -1,0 +1,7 @@
+export type TodoInCalendar = {
+  title: string;
+  start: string;
+  end: string;
+};
+
+export type TodosInCalendar = TodoInCalendar[];


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #23 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] calender data 오류 수정
- [ ] supabase 투두리스트 title, start, end 타입 string 으로 수정

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
<!-- TroubleShotting이 있었다면 이야기 해주세요! -->
![스크린샷 2024-03-20 오후 9 04 19](https://github.com/wonjangnimsamgyetang-team3/followingfollower/assets/142870577/271054d2-106b-4d83-bebc-49f78c2d283b)
supabase 데이터를 fullcalendar 에 바로 넣으니까
fullcalendar 에서 지정한 events 의 속성이 저희가 올려둔 투두리스트 데이터랑 달라서 에러가 떴었어요.
가져온 데이터에서 우선 지금 필요한 title, start, end 만 새로 배열에 넣어서 해결했습니다.

calendar.tsx
```ts
  const todos: TodosInCalendar = [];

//..
  data?.map((item) =>
    todos.push({
      title: item.title,
      start: item.start,
      end: item.end,
    })
  );
```
##  TroubleShotting
supabase 에서 가져와서 새 배열에 넣으니까 null 값은 할당될 수 없다는 new.. 에러가 떴습니다.
title, start, end 타입은 필수값이니 supabase 설정에서 Null 허용 옵션을 끄고 타입 파일도 수정했습니다.

database.type.ts
```ts
TodoList: {
        Row: {
          contents: string | null;
          created_at: string;
          end: string;
          file: string | null;
          likeCount: number | null;
          liked: boolean | null;
          nickname: string | null;
          start: string;
          title: string;
          todoId: string;
        };
```
## 📸 스크린샷(선택)
```
```
## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
